### PR TITLE
Fix an issue with an url that includes `@` in the path

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,5 +4,5 @@ module.exports = function (str) {
 		throw new TypeError('Expected a string');
 	}
 
-	return str.replace(/^((?:\w+:)?\/\/)(?:[^@]+@)/, '$1');
+	return str.replace(/^((?:\w+:)?\/\/)(?:[^@\/]+@)/, '$1');
 };

--- a/test.js
+++ b/test.js
@@ -7,6 +7,7 @@ test(function (t) {
 	t.assert(stripUrlAuth('https://user:pass@sindresorhus.com') === 'https://sindresorhus.com');
 	t.assert(stripUrlAuth('//user:pass@sindresorhus.com') === '//sindresorhus.com');
 	t.assert(stripUrlAuth('http://user@sindresorhus.com') === 'http://sindresorhus.com');
+	t.assert(stripUrlAuth('http://sindresorhus.com/@foo') === 'http://sindresorhus.com/@foo');
 	t.assert(stripUrlAuth('http://sindresorhus.com') === 'http://sindresorhus.com');
 	t.end();
 });


### PR DESCRIPTION
I'm using this module with `humanize-url`.
I've found an issue with an url that includes `@` in the path.

Example: 

``` javascript
stripUrlAuth('https://www.flickr.com/photos/132454635@N08/19092666468/')
//=> 'https://N08/19092666468/'

stripUrlAuth('https://medium.com/@kristynazdot/the-37-best-websites-to-learn-something-new-895e2cb0cad4')
//=> 'https://kristynazdot/the-37-best-websites-to-learn-something-new-895e2cb0cad4'
```

This PR fixes this issue.
I think this fixes the same problem in `humanize-url` if it's merged.
