### PR TITLE
update travis targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
+  - '8'
   - '6'
   - '4'
-  - '0.12'
-  - '0.10'


### PR DESCRIPTION
This just updates the target versions for Travis. Basically with the newest versions of XO (and possibly Ava) that are installed and used in tests it will fail for anything less than `4.x`.